### PR TITLE
Revert "DATA-454 Optimize DBT model materialization"

### DIFF
--- a/models/base/snowplow_base_events.sql
+++ b/models/base/snowplow_base_events.sql
@@ -1,22 +1,17 @@
-{{
-    config(
-        materialized='incremental',
-        sort=['platform','event_name'],
-        dist='sequence_number',
-        sql_where='TRUE',
-        unique_key='sequence_number',
-        primary_key='sequence_number'
-    )
-}}
-
 with source as (
 
-    select * from {{ref('sp_base_events_fivetran')}}
-    {% if adapter.already_exists(this.schema, this.name) and not flags.FULL_REFRESH %}
-    where collector_tstamp > (
-        select coalesce(max(collector_tstamp), '0001-01-01') from {{ this }}
-    )
+    select * from
+
+    {% if var('snowplow:use_fivetran_interface') %}
+
+        {{ref('sp_base_events_fivetran')}}
+
+    {% else %}
+
+        {{ var('snowplow:events') }}
+
     {% endif %}
+
 ),
 
 filtered as (


### PR DESCRIPTION
Reverts catchco/snowplow#3

Materializing this table appears to be causing disk full errors during `Build & Test` teamcity runs.