### PR TITLE
Remove uniqueness test for snowplow sessions model

### DIFF
--- a/models/sessions/schema.yml
+++ b/models/sessions/schema.yml
@@ -4,8 +4,5 @@ snowplow_sessions:
         not_null:
             - session_id
 
-        unique:
-            - session_id
-
         relationships:
             - {from: session_id, to: ref('snowplow_page_views'), field: session_id}


### PR DESCRIPTION
Due to order ref number being brought in, this will never be unique.